### PR TITLE
:construction_worker: Don't build for Mac

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         build_type: ['Debug', 'Release']
         config:
-          - { name: '🍏 macOS Clang', os: macos-latest }
           - { name: '🐧 Linux GCC', os: ubuntu-latest }
           - { name: '🪟 Windows MSVC', os: windows-latest }
 
@@ -25,10 +24,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Install Dependencies (macOS)
-        if: matrix.config.os == 'macos-latest'
-        run: brew install ccache ninja
 
       - name: Install Dependencies (Linux)
         if: matrix.config.os == 'ubuntu-latest'


### PR DESCRIPTION
We don't particularly care about building for mac. Was in build matrix
out of curiosity about whether it would "just work". It seems to be
having some issues with godot Variant types. No interest in figuring out
why. Dropping from matrix.
